### PR TITLE
fix: missing gazebo environment setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,29 +2,28 @@ FROM althack/ros2:humble-dev
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-humble-navigation2 \
-    ros-humble-nav2-bringup \ 
-    ros-humble-turtlebot3-msgs \
-    ros-humble-turtlebot3 \
-    ros-humble-turtlebot3-gazebo \
-    nano \
-    tmux \
-    && rm -rf /var/lib/apt/lists/*
+	ros-humble-navigation2 \
+	ros-humble-nav2-bringup \
+	ros-humble-turtlebot3-msgs \
+	ros-humble-turtlebot3 \
+	ros-humble-turtlebot3-gazebo \
+	nano \
+	tmux \
+	&& rm -rf /var/lib/apt/lists/*
 ENV DEBIAN_FRONTEND=dialog
+ENV TURTLEBOT3_MODEL=burger
 
 # Additional pip packages
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --upgrade pip \
- && pip install --no-cache-dir --timeout 2000 -r /tmp/requirements.txt
-
+	&& pip install --no-cache-dir --timeout 2000 -r /tmp/requirements.txt
 
 # Set up auto-source of workspace for ros user
 ARG WORKSPACE
 RUN echo "if [ -f ${WORKSPACE}/install/setup.bash ]; then source ${WORKSPACE}/install/setup.bash; fi" >> /home/ros/.bashrc
 
-# Set env variables for Nav2
-RUN echo "export TURTLEBOT3_MODEL=burger" >> /home/ros/.bashrc
-RUN echo "export GAZEBO_MODEL_PATH=\$GAZEBO_MODEL_PATH:/opt/ros/humble/share/turtlebot3_gazebo/models" >> /home/ros/.bashrc
-RUN echo "export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:$(ros2 pkg prefix mpc)/share/mpc/models" >> /home/ros/.bashrc
-RUN echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> /home/ros/.bashrc
-RUN echo "export CYCLONEDDS_URI=${WORKSPACE}/setup/cyclonedds_lo.xml" >> /home/ros/.bashrc
+# make sure the ROS env is set up for the whole container (not just interactive shell)
+COPY ros_entrypoint.sh /usr/local/bin/ros_entrypoint.sh
+RUN chmod +x /usr/local/bin/ros_entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/.devcontainer/ros_entrypoint.sh
+++ b/.devcontainer/ros_entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+## make sure the ROS environment is set up for every container
+## command, not just interactive shells
+#
+set -e
+
+# Source ROS
+source /opt/ros/humble/setup.bash
+if [ -f "/usr/share/gazebo/setup.sh" ]; then source /usr/share/gazebo/setup.sh; fi
+
+# Source workspace if present
+if [ -f "/workspaces/ros2_ws/install/setup.bash" ]; then source /workspaces/ros2_ws/install/setup.bash; fi
+
+# Turtlebot models
+export GAZEBO_MODEL_PATH="${GAZEBO_MODEL_PATH}:/opt/ros/humble/share/turtlebot3_gazebo/models"
+
+# Optional package-based path
+if ros2 pkg prefix mpc >/dev/null 2>&1; then
+    export GAZEBO_MODEL_PATH="${GAZEBO_MODEL_PATH}:$(ros2 pkg prefix mpc)/share/mpc/models"
+fi
+
+# Optional Cyclone config (only if you really want Cyclone)
+if [ -f "/workspaces/ros2_ws/setup/cyclonedds_lo.xml" ]; then
+    export CYCLONEDDS_URI="/workspaces/ros2_ws/setup/cyclonedds_lo.xml"
+fi
+
+exec "$@"


### PR DESCRIPTION
- i.e., set up `GAZEBO_PLUGIN_PATH` by sourcing `gazebot setup.sh`.
- Do not force `RMW_IMPLEMENTATION`; let ROS automatically decide.
